### PR TITLE
Add: HTMLにバリデートをかけるタスクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ HTMLとCSSとJSの整形とリントをまとめて実行します。
 npm run lint
 ```
 
-[HTMLHint](https://github.com/htmlhint/HTMLHint)でHTMLのリントを実行します。
+[HTMLHint](https://github.com/htmlhint/HTMLHint)と[gulp-w3cjs](https://github.com/callumacrae/gulp-w3cjs)でHTMLのリントとW3Cのバリデーションを実行します。
 
 ```bash
-npm run htmlhint
+npm run htmlValidate
 ```
 
 [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard)を元にSassのリントを実行します。

--- a/package-lock.json
+++ b/package-lock.json
@@ -3321,6 +3321,12 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -6070,6 +6076,12 @@
         }
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -7929,6 +7941,59 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        }
+      }
+    },
+    "gulp-w3cjs": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/gulp-w3cjs/-/gulp-w3cjs-1.3.2.tgz",
+      "integrity": "sha512-nqDL0wwot3PdQCAbbwvT2zstTP584tnoCkgAFiECX7XRR4QRfRAufQlCohvvYfPAMohyPUR3Bhe/UmK+n9TDqQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.2.1",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^1.0.1",
+        "through2": "^3.0.1",
+        "w3cjs": "^0.4.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+          "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+          "dev": true
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-colors": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+              "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+              "dev": true,
+              "requires": {
+                "ansi-wrap": "^0.1.0"
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
         }
       }
     },
@@ -10725,6 +10790,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "micromatch": {
@@ -18546,6 +18617,42 @@
         "postcss": "^7.0.2"
       }
     },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        }
+      }
+    },
+    "superagent-proxy": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.3.tgz",
+      "integrity": "sha512-79Ujg1lRL2ICfuHUdX+H2MjIw73kB7bXsIkxLwHURz3j0XUmEEEoJ+u/wq+mKwna21Uejsm2cGR3OESA00TIjA==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "proxy-agent": "2"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -20315,6 +20422,17 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "w3cjs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/w3cjs/-/w3cjs-0.4.0.tgz",
+      "integrity": "sha1-EzYk4LhlYmfPanCF2NfGlLcPBI8=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "superagent": "^3.5.2",
+        "superagent-proxy": "^1.0.2"
       }
     },
     "watchify": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "APP_ENV=development gulp",
     "test": "npm run lint && APP_ENV=production gulp",
     "release": "npm run lint && APP_ENV=production gulp build",
-    "htmlhint": "APP_ENV=development gulp htmlhint",
+    "htmlValidate": "APP_ENV=development gulp htmlValidate",
     "stylelint": "APP_ENV=development gulp stylelint",
     "eslint": "eslint --fix src/**/*.js",
     "lint": "npm run htmlhint && npm run stylelint && npm run eslint"
@@ -70,6 +70,7 @@
     "gulp-stylelint": "^8.0.0",
     "gulp-svg-sprite": "^1.5.0",
     "gulp-uglify": "^3.0.1",
+    "gulp-w3cjs": "^1.3.2",
     "htmlhint-stylish": "^1.0.3",
     "imagemin-mozjpeg": "^8.0.0",
     "imagemin-pngquant": "^7.0.0",


### PR DESCRIPTION
ページ数が多いと各ページでバリデートをかけるのが大変になる。
基本は1ページ作成ごとにかけたいが、公開前の一斉チェックでも確認できるようにする。
`validateDir`を変えることで、カテゴリごとにチェックもできる。

#204